### PR TITLE
[feature] Add support for numbers as keys of colors

### DIFF
--- a/example/theme.ts
+++ b/example/theme.ts
@@ -16,16 +16,16 @@ export const theme = {
       dark: "#cbb700",
     },
     neutral: {
-      "0": "#ffffff",
-      "1": "#f5f5f5",
-      "2": "#edecf0",
-      "3": "#d8d7df",
-      "4": "#898896",
-      "5": "#666472",
-      "6": "#424149",
-      "7": "#27262c",
-      "8": "#131316",
-      "9": "#050505",
+      0: "#ffffff",
+      1: "#f5f5f5",
+      2: "#edecf0",
+      3: "#d8d7df",
+      4: "#898896",
+      5: "#666472",
+      6: "#424149",
+      7: "#27262c",
+      8: "#131316",
+      9: "#050505",
     },
   },
   radius: {
@@ -96,7 +96,13 @@ type Radius = typeof theme.radius;
 
 type CustomProps = Omit<
   typeof theme,
-  "breakpoint" | "spacing" | "palette" | "radius" | "zIndex" | "typography" | "defaultBorder"
+  | "breakpoint"
+  | "spacing"
+  | "palette"
+  | "radius"
+  | "zIndex"
+  | "typography"
+  | "defaultBorder"
 >;
 
 declare module "e-prim" {

--- a/lib/theme/types.ts
+++ b/lib/theme/types.ts
@@ -20,7 +20,10 @@ export interface TTypography {}
 export interface TCustomProps {}
 
 export type PaletteKey = Join<PathsToStringProps<TPalette>> | "transparent";
-export type TypographyKey = Join<PathsToStringProps<TTypography, TypographySpecs>> | "default";
+
+export type TypographyKey =
+  | Join<PathsToStringProps<TTypography, TypographySpecs>>
+  | "default";
 
 export interface BaseTheme extends TCustomProps {
   /**
@@ -80,7 +83,7 @@ interface TypographyConfig {
 }
 
 interface ColorConfig {
-  [index: string]: CSSObject["color"] | ColorConfig;
+  [index: string | number]: CSSObject["color"] | ColorConfig;
 }
 
 export type ThemeConfig = {

--- a/lib/utils/dot-object.ts
+++ b/lib/utils/dot-object.ts
@@ -1,25 +1,35 @@
 export type PathsToStringProps<T, TStopType = string> = T extends TStopType
   ? []
   : {
-      [K in Extract<keyof T, string>]: [K, ...PathsToStringProps<T[K], TStopType>];
-    }[Extract<keyof T, string>];
+      [K in Extract<keyof T, string | number>]: [
+        K,
+        ...PathsToStringProps<T[K], TStopType>
+      ];
+    }[Extract<keyof T, string | number>];
 
-export type Join<T extends string[], D extends string = "."> = T extends []
+export type Join<
+  T extends (string | number)[],
+  D extends string = "."
+> = T extends []
   ? never
   : T extends [infer F]
   ? F
   : T extends [infer F, ...infer R]
-  ? F extends string
-    ? `${F}${D}${Join<Extract<R, string[]>, D>}`
+  ? F extends string | number
+    ? `${F}${D}${Join<Extract<R, (string | number)[]>, D>}`
     : never
-  : string;
+  : string | number;
 
 /**
  * Given a color key (dot-based deep path), resolves the actual color value
  * @param key dot-based path
  * @param object reference to the main object that should be used to find the value
  */
-export const getValueFromKey = <TValue, TKey extends string = string, TObject = {}>(
+export const getValueFromKey = <
+  TValue,
+  TKey extends string = string,
+  TObject = {}
+>(
   key: TKey | undefined,
   object: TObject
 ): TValue | undefined => {


### PR DESCRIPTION
Before this change, any numeric color key would not work properly in building the color key string. Now the key is changed from `string` to `string | number`