### PR TITLE
[feature] Add a transparency util in the theme (#6)

### DIFF
--- a/docs/docs/theme-utils.md
+++ b/docs/docs/theme-utils.md
@@ -1,0 +1,64 @@
+---
+title: Theme Utils
+sidebar_position: 3
+---
+
+When configuring the emotion theme, `e-prim` automatically adds a few utils to the theme. You will have those available everywhere you use the theme (`useTheme` hook, `css` prop, `styled`)
+
+Here is the list of utils that are configured for the theme:
+
+## mediaUp/mediaDown
+
+`mediaUp/mediaDown (breakpoint: keyof TBreakpoint)`
+
+You can use those functions to generate a media query based on the breakpoints in your theme. This is usually useful as part of `css` prop or `styled` if you want a specific responsive value that's not available using the box system. Example:
+
+```tsx
+// given
+<Box
+  css={({ mediaUp }) => ({
+    width: 100,
+    height: 100,
+    [mediaUp("md")]: {
+      width: "100%"
+    },
+    [mediaDown("md")]: {
+      height: "100%"
+    }
+  })}
+/>
+
+// you get
+{
+  width: "100px",
+  height: "100px",
+  "@media (min-width: 500px)": {
+    width: "100%"
+  },
+  "@media (max-width: 500px)": {
+    height: "100%"
+  }
+}
+```
+
+## spacing
+
+`spacing(...SpacingUnit)`
+
+The spacing util is the same one that you can use in the box system (margins/paddings/gaps). It's actually what's used under the hood in the box. You can pass 1-4 parameters in either a string or numeric form. If the value is a number, it would automatically be converted to pixels. Apart from that, it works exactly like you would expect it in the CSS margin/padding syntax.
+
+```tsx
+<Box
+  css={({ spacing }) => ({
+    marginLeft: spacing(10), // 40px
+    marginTop: "10%",
+    marginBottom: "5vh"
+  })}
+/>
+```
+
+## transparentColor
+
+`transparentColor(key: PaletteKey, opacity: number)`
+
+The transparent color util takes a key from your palette as well as a transparency value. Based on that, it resolves the color, tries to get it's type (hex, rgb, hsl) and applies the provided opacity. Opacity is interpreted as a percentage (0 - 100);

--- a/docs/docs/theme-utils.md
+++ b/docs/docs/theme-utils.md
@@ -62,3 +62,17 @@ The spacing util is the same one that you can use in the box system (margins/pad
 `transparentColor(key: PaletteKey, opacity: number)`
 
 The transparent color util takes a key from your palette as well as a transparency value. Based on that, it resolves the color, tries to get it's type (hex, rgb, hsl) and applies the provided opacity. Opacity is interpreted as a percentage (0 - 100);
+
+## colorByKey
+
+`colorByKey(key: PaletteColor)`
+
+Resolves the color value given a palette key from your theme configuration
+
+```tsx
+<Box
+  css={({ colorByKey }) => ({
+    color: colorByKey("neutral.0")
+  })}
+/>
+```

--- a/lib/hooks/use-color-by-key.ts
+++ b/lib/hooks/use-color-by-key.ts
@@ -2,8 +2,8 @@ import { useTheme } from "@emotion/react";
 import { PaletteKey } from "../theme";
 import { getValueFromKey } from "../utils/dot-object";
 
-export const useColorByKey = (key: PaletteKey | undefined) => {
+export const useColorByKey = (key: PaletteKey | undefined): string | undefined => {
   const { palette } = useTheme();
 
-  return getValueFromKey(key, palette);
+  return getValueFromKey<string>(key, palette);
 };

--- a/lib/hooks/use-color-by-key.ts
+++ b/lib/hooks/use-color-by-key.ts
@@ -1,9 +1,9 @@
 import { useTheme } from "@emotion/react";
+import { colorByKey } from "../system/theme-functions";
 import { PaletteKey } from "../theme";
-import { getValueFromKey } from "../utils/dot-object";
 
 export const useColorByKey = (key: PaletteKey | undefined): string | undefined => {
   const { palette } = useTheme();
 
-  return getValueFromKey<string>(key, palette);
+  return colorByKey(key, palette);
 };

--- a/lib/system/__tests__/theme-functions.test.ts
+++ b/lib/system/__tests__/theme-functions.test.ts
@@ -1,7 +1,7 @@
 import { mockTheme } from "../../utils/mock-theme";
-import { mediaDown, mediaUp, spacing, transparentColor } from "../theme-functions";
+import { colorByKey, mediaDown, mediaUp, spacing, transparentColor } from "../theme-functions";
 
-let mockColor = "";
+let mockColor: string | undefined;
 jest.mock("../../utils/dot-object", () => ({
   getValueFromKey: () => mockColor,
 }));
@@ -35,6 +35,12 @@ describe("theme-functions", () => {
   });
 
   describe("transparentColor", () => {
+    test("should warn if the color key is not found", () => {
+      mockColor = undefined;
+
+      expect(transparentColor("neutral.0", 10, mockTheme.palette)).toBeUndefined();
+    });
+
     test("should make hex value transparent", () => {
       mockColor = "#001122";
 
@@ -73,5 +79,20 @@ describe("theme-functions", () => {
       expect(transparentColor("neutral.0", 10, mockTheme.palette)).toEqual(mockColor);
       expect(warn).toHaveBeenCalledWith("Color invalid was not recognized as any valid type of color");
     });
+  });
+});
+
+describe("color by key", () => {
+  test("should return nothing if the color is not found", () => {
+    mockColor = undefined;
+
+    colorByKey("neutral.0", mockTheme.palette);
+
+    expect(warn).toHaveBeenCalledWith("Could not find color by key neutral.0");
+  });
+
+  test("should return color", () => {
+    mockColor = "#ffffff";
+    expect(colorByKey("neutral.0", mockTheme.palette)).toEqual("#ffffff");
   });
 });

--- a/lib/system/__tests__/theme-functions.test.ts
+++ b/lib/system/__tests__/theme-functions.test.ts
@@ -1,5 +1,12 @@
 import { mockTheme } from "../../utils/mock-theme";
-import { mediaDown, mediaUp, spacing } from "../theme-functions";
+import { mediaDown, mediaUp, spacing, transparentColor } from "../theme-functions";
+
+let mockColor = "";
+jest.mock("../../utils/dot-object", () => ({
+  getValueFromKey: () => mockColor,
+}));
+
+const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
 
 describe("theme-functions", () => {
   describe("mediaDown", () => {
@@ -25,5 +32,46 @@ describe("theme-functions", () => {
 
     test("should return mixed values", () =>
       expect(spacing(mockTheme.spacingValue, "10px", 4, "10%", 8)).toEqual("10px 16px 10% 32px"));
+  });
+
+  describe("transparentColor", () => {
+    test("should make hex value transparent", () => {
+      mockColor = "#001122";
+
+      expect(transparentColor("neutral.0", 10, mockTheme.palette)).toEqual("#0011221a");
+    });
+
+    test("should make rgb value transparent", () => {
+      mockColor = "rgb(12, 24, 36)";
+
+      expect(transparentColor("neutral.0", 10, mockTheme.palette)).toEqual("rgba(12, 24, 36, 0.1)");
+    });
+
+    test("should warn when making a rgb value transparent if it cannot be parsed", () => {
+      mockColor = "rgb__";
+
+      expect(transparentColor("neutral.0", 10, mockTheme.palette)).toEqual(mockColor);
+      expect(warn).toHaveBeenCalledWith("Could not parse color rgb__ as a valid rgb color");
+    });
+
+    test("should make hsl value transparent", () => {
+      mockColor = "hsl(10, 25%, 50%)";
+
+      expect(transparentColor("neutral.0", 10, mockTheme.palette)).toEqual("hsla(10, 25%, 50%, 0.1)");
+    });
+
+    test("should warn when making a hsl value transparent if it cannot be parsed", () => {
+      mockColor = "hsl__";
+
+      expect(transparentColor("neutral.0", 10, mockTheme.palette)).toEqual(mockColor);
+      expect(warn).toHaveBeenCalledWith("Could not parse color hsl__ as a valid hsl color");
+    });
+
+    test("should warn when value cannot be parsed as a valid color", () => {
+      mockColor = "invalid";
+
+      expect(transparentColor("neutral.0", 10, mockTheme.palette)).toEqual(mockColor);
+      expect(warn).toHaveBeenCalledWith("Color invalid was not recognized as any valid type of color");
+    });
   });
 });

--- a/lib/system/theme-functions.ts
+++ b/lib/system/theme-functions.ts
@@ -15,8 +15,22 @@ export const mediaUp = (breakpoint: keyof TBreakpoint, themeBreakpoint: TBreakpo
 export const spacing = (spacingValue: number, ...values: SpacingUnit[]) =>
   values.map(item => pxOrRaw(item, item => item * spacingValue)).join(" ");
 
+export const colorByKey = (key: PaletteKey | undefined, palette: TPalette) => {
+  const color = getValueFromKey<string>(key, palette);
+  if (!color) {
+    console.warn(`Could not find color by key ${key}`);
+    return;
+  }
+
+  return color;
+};
+
 export const transparentColor = (key: PaletteKey, opacity: number, palette: TPalette) => {
-  const color = String(getValueFromKey(key, palette));
+  const color = colorByKey(key, palette);
+
+  if (!color) {
+    return;
+  }
 
   if (color.startsWith("#")) {
     return `${color}${percentToHex(opacity)}`;

--- a/lib/system/theme-functions.ts
+++ b/lib/system/theme-functions.ts
@@ -1,5 +1,10 @@
-import { SpacingUnit, TBreakpoint } from "../theme";
+import { PaletteKey, SpacingUnit, TBreakpoint, TPalette } from "../theme";
+import { percentToHex } from "../utils/color-utils";
+import { getValueFromKey } from "../utils/dot-object";
 import { pxOrRaw } from "../utils/px-or-raw";
+
+const REGEX_RGB = /rgb\((\d{1,3}), (\d{1,3}), (\d{1,3})\)/;
+const REGEX_HSL = /hsl\((\d+), (\d+)%, (\d+)%\)/;
 
 export const mediaDown = (breakpoint: keyof TBreakpoint, themeBreakpoint: TBreakpoint) =>
   `@media (max-width: ${themeBreakpoint[breakpoint]}px)`;
@@ -9,3 +14,36 @@ export const mediaUp = (breakpoint: keyof TBreakpoint, themeBreakpoint: TBreakpo
 
 export const spacing = (spacingValue: number, ...values: SpacingUnit[]) =>
   values.map(item => pxOrRaw(item, item => item * spacingValue)).join(" ");
+
+export const transparentColor = (key: PaletteKey, opacity: number, palette: TPalette) => {
+  const color = String(getValueFromKey(key, palette));
+
+  if (color.startsWith("#")) {
+    return `${color}${percentToHex(opacity)}`;
+  }
+
+  if (color.startsWith("rgb")) {
+    const matches = REGEX_RGB.exec(color);
+
+    if (!matches) {
+      console.warn(`Could not parse color ${color} as a valid rgb color`);
+      return color;
+    }
+
+    return `rgba(${matches[1]}, ${matches[2]}, ${matches[3]}, ${opacity / 100})`;
+  }
+
+  if (color.startsWith("hsl")) {
+    const matches = REGEX_HSL.exec(color);
+
+    if (!matches) {
+      console.warn(`Could not parse color ${color} as a valid hsl color`);
+      return color;
+    }
+
+    return `hsla(${matches[1]}, ${matches[2]}%, ${matches[3]}%, ${opacity / 100})`;
+  }
+
+  console.warn(`Color ${color} was not recognized as any valid type of color`);
+  return color;
+};

--- a/lib/theme/__tests__/theme-provider.test.tsx
+++ b/lib/theme/__tests__/theme-provider.test.tsx
@@ -17,5 +17,6 @@ describe("theme provider", () => {
     expect(result.result.current.mediaDown("md")).toEqual("@media (max-width: 500px)");
     expect(result.result.current.mediaUp("md")).toEqual("@media (min-width: 500px)");
     expect(result.result.current.spacing(4)).toEqual("16px");
+    expect(result.result.current.transparentColor("neutral.1", 10)).toEqual("#f5f5f51a");
   });
 });

--- a/lib/theme/__tests__/theme-provider.test.tsx
+++ b/lib/theme/__tests__/theme-provider.test.tsx
@@ -18,5 +18,6 @@ describe("theme provider", () => {
     expect(result.result.current.mediaUp("md")).toEqual("@media (min-width: 500px)");
     expect(result.result.current.spacing(4)).toEqual("16px");
     expect(result.result.current.transparentColor("neutral.1", 10)).toEqual("#f5f5f51a");
+    expect(result.result.current.colorByKey("neutral.1")).toEqual("#f5f5f5");
   });
 });

--- a/lib/theme/theme-provider.tsx
+++ b/lib/theme/theme-provider.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import { PropsWithChildren } from "react";
-import { transparentColor, mediaDown, mediaUp, spacing } from "../system/theme-functions";
+import { transparentColor, mediaDown, mediaUp, spacing, colorByKey } from "../system/theme-functions";
 import { BaseTheme, PaletteKey, SpacingUnit, TBreakpoint, ThemeConfig, TPalette } from "./types";
 
 export type ThemeProviderProps<TTheme extends ThemeConfig> = {
@@ -13,6 +13,7 @@ export const makeTheme = <TTheme extends ThemeConfig>(config: TTheme) => ({
   mediaUp: (breakpoint: keyof TBreakpoint) => mediaUp(breakpoint, config.breakpoint),
   spacing: (...values: SpacingUnit[]) => spacing(config.spacing, ...values),
   transparentColor: (key: PaletteKey, opacity: number) => transparentColor(key, opacity, config.palette as TPalette),
+  colorByKey: (key: PaletteKey) => colorByKey(key, config.palette as TPalette),
   spacingValue: config.spacing,
 });
 

--- a/lib/theme/theme-provider.tsx
+++ b/lib/theme/theme-provider.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 import { PropsWithChildren } from "react";
-import { mediaDown, mediaUp, spacing } from "../system/theme-functions";
-import { BaseTheme, SpacingUnit, TBreakpoint, ThemeConfig } from "./types";
+import { transparentColor, mediaDown, mediaUp, spacing } from "../system/theme-functions";
+import { BaseTheme, PaletteKey, SpacingUnit, TBreakpoint, ThemeConfig, TPalette } from "./types";
 
 export type ThemeProviderProps<TTheme extends ThemeConfig> = {
   theme: TTheme;
@@ -12,6 +12,7 @@ export const makeTheme = <TTheme extends ThemeConfig>(config: TTheme) => ({
   mediaDown: (breakpoint: keyof TBreakpoint) => mediaDown(breakpoint, config.breakpoint),
   mediaUp: (breakpoint: keyof TBreakpoint) => mediaUp(breakpoint, config.breakpoint),
   spacing: (...values: SpacingUnit[]) => spacing(config.spacing, ...values),
+  transparentColor: (key: PaletteKey, opacity: number) => transparentColor(key, opacity, config.palette as TPalette),
   spacingValue: config.spacing,
 });
 

--- a/lib/theme/types.ts
+++ b/lib/theme/types.ts
@@ -74,6 +74,7 @@ export interface BaseTheme extends TCustomProps {
   mediaUp: (breakpoint: keyof TBreakpoint) => string;
   spacing: (...values: SpacingUnit[]) => string;
   transparentColor: (key: PaletteKey, opacity: number) => string;
+  colorByKey: (key: PaletteKey) => string;
 }
 
 interface TypographyConfig {

--- a/lib/theme/types.ts
+++ b/lib/theme/types.ts
@@ -73,6 +73,7 @@ export interface BaseTheme extends TCustomProps {
   mediaDown: (breakpoint: keyof TBreakpoint) => string;
   mediaUp: (breakpoint: keyof TBreakpoint) => string;
   spacing: (...values: SpacingUnit[]) => string;
+  transparentColor: (key: PaletteKey, opacity: number) => string;
 }
 
 interface TypographyConfig {

--- a/lib/utils/color-utils.ts
+++ b/lib/utils/color-utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Converts a decimal percent to hex
+ * @param p percent to convert. Should be an integer between 0 and 100, other values are bounded to that range.
+ * Decimal values are rounded to the nearest integer
+ */
+export const percentToHex = (p: number) => {
+  const percent = Math.max(0, Math.min(100, p)); // bound percent from 0 to 100
+  const intValue = Math.round((percent / 100) * 255); // map percent to nearest integer (0 - 255)
+  const hexValue = intValue.toString(16); // get hexadecimal representation
+
+  return hexValue.padStart(2, "0"); // format with leading 0
+};


### PR DESCRIPTION
Also adds `colorByKey` to the theme utils, as well as generally document the theme utils and their usage