### PR TITLE
[bug] Fix as prop for typography and flex

### DIFF
--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -11,7 +11,7 @@ export default function () {
     <Flex direction="column" gap={4} p={4} width="100%" m={{ xs: 2, md: 4 }}>
       <Typography variant="title.1">e-prim</Typography>
 
-      <Typography variant="body.1">
+      <Typography variant="body.1" as="p">
         A set of tools to implement a design system on top of @emotion/css and @emotion/react as well as add some
         primitive components to make prototyping UI faster and easier
       </Typography>

--- a/lib/components/flex.tsx
+++ b/lib/components/flex.tsx
@@ -8,7 +8,10 @@ const DEFAULT_TAG = "div";
 
 type OwnProps = FlexSystem;
 
-export type FlexProps<E extends ElementType> = BoxProps<E> & OwnProps;
+export type FlexProps<E extends ElementType> = BoxProps<E> &
+  OwnProps & {
+    as?: E;
+  };
 
 /**
  * The Flex component is a primitive that exposes useful properties for faster prototyping of flex layouts

--- a/lib/components/typography.tsx
+++ b/lib/components/typography.tsx
@@ -9,7 +9,10 @@ const DEFAULT_TAG = "span";
 
 type OwnProps = TypographySystem;
 
-export type TypographyProps<E extends ElementType> = Omit<BoxProps<E>, "typography"> & OwnProps;
+export type TypographyProps<E extends ElementType> = Omit<BoxProps<E>, "typography"> &
+  OwnProps & {
+    as?: E;
+  };
 
 export const Typography: <E extends ElementType = typeof DEFAULT_TAG>(
   props: TypographyProps<E>,


### PR DESCRIPTION
As prop was not properly inherited from the BOX and it was not allowing different values than span (for typography) or div (for flex). This is now fixed by overriding the `as` prop in the component props definition;