### PR TITLE
[bug] Fix transparent color being ignored as it's not part of the palette

### DIFF
--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -34,9 +34,13 @@ export default function () {
 
       <StyledBox>Styled Text</StyledBox>
 
-      <Flex direction={{ xs: "column", md: "row" }} gap={{ xs: 2, md: 4 }} p={4}>
-        <Box>item1</Box>
-        <Box>item2</Box>
+      <Flex direction={{ xs: "column", md: "row" }} gap={{ xs: 2, md: 4 }} p={4} background="neutral.6">
+        <Box background="neutral.3" p={4}>
+          item1
+        </Box>
+        <Box background="transparent" p={4}>
+          item2
+        </Box>
       </Flex>
 
       <Grid columns={[2, [100, 200]]}>

--- a/lib/system/__tests__/css-props-system.test.ts
+++ b/lib/system/__tests__/css-props-system.test.ts
@@ -49,7 +49,7 @@ describe("css props system", () => {
       expect(
         createCssProps(
           {
-            background: "neutral.4",
+            background: "transparent",
             border: "neutral.7",
             width: {
               xs: "100%",
@@ -75,7 +75,7 @@ describe("css props system", () => {
         {},
         {},
         {},
-        { background: "#898896" },
+        { background: "transparent" },
         {
           "@media (min-width: 500px)": {
             boxShadow: "0px 48px 80px -32px rgba(55, 56, 74, 0.12), 0px 64px 132px -20px rgba(55, 56, 74, 0.08)",

--- a/lib/system/css-props-system.ts
+++ b/lib/system/css-props-system.ts
@@ -4,6 +4,7 @@ import { pxOrRaw } from "../utils/px-or-raw";
 import { createValue } from "./create-value";
 import { getAllPropKeys } from "./get-all-prop-keys";
 import { responsiveCssValueFactory } from "./responsive-css-value-factory";
+import { colorByKey } from "./theme-functions";
 import { CssProperties, ResponsiveValue } from "./types";
 import { getTypographyStyles } from "./typography-system";
 
@@ -33,10 +34,10 @@ export const createCssProps = (props: CssPropsSystem, theme: BaseTheme): CssProp
     shadow,
   } = props;
 
-  const colorTransformer = (value: PaletteKey) => getValueFromKey<string>(value, theme.palette);
+  const colorTransformer = (value: PaletteKey) => colorByKey(value, theme.palette);
   const borderTransformer = (value: PaletteKey | boolean) => {
     const width = pxOrRaw(theme.border?.width ?? 1);
-    const color = getValueFromKey(value === true ? theme.border?.color : (value as string), theme.palette);
+    const color = colorByKey(value === true ? theme.border?.color : (value as PaletteKey | undefined), theme.palette);
 
     return `${width} solid ${color}`;
   };

--- a/lib/system/safe-colors.ts
+++ b/lib/system/safe-colors.ts
@@ -1,0 +1,1 @@
+export const safeColors = ["transparent"] as const;

--- a/lib/system/theme-functions.ts
+++ b/lib/system/theme-functions.ts
@@ -2,6 +2,7 @@ import { PaletteKey, SpacingUnit, TBreakpoint, TPalette } from "../theme";
 import { percentToHex } from "../utils/color-utils";
 import { getValueFromKey } from "../utils/dot-object";
 import { pxOrRaw } from "../utils/px-or-raw";
+import { safeColors } from "./safe-colors";
 
 const REGEX_RGB = /rgb\((\d{1,3}), (\d{1,3}), (\d{1,3})\)/;
 const REGEX_HSL = /hsl\((\d+), (\d+)%, (\d+)%\)/;
@@ -17,6 +18,11 @@ export const spacing = (spacingValue: number, ...values: SpacingUnit[]) =>
 
 export const colorByKey = (key: PaletteKey | undefined, palette: TPalette) => {
   const color = getValueFromKey<string>(key, palette);
+
+  if (!color && key && safeColors.includes(key as typeof safeColors[number])) {
+    return key;
+  }
+
   if (!color) {
     console.warn(`Could not find color by key ${key}`);
     return;

--- a/lib/theme/types.ts
+++ b/lib/theme/types.ts
@@ -1,3 +1,4 @@
+import { safeColors } from "../system/safe-colors";
 import { CssProperties } from "../system/types";
 import { Join, PathsToStringProps } from "../utils/dot-object";
 
@@ -20,7 +21,7 @@ export interface TTypography {}
 
 export interface TCustomProps {}
 
-export type PaletteKey = Join<PathsToStringProps<TPalette>> | "transparent";
+export type PaletteKey = Join<PathsToStringProps<TPalette>> | typeof safeColors[number];
 export type TypographyKey = Join<PathsToStringProps<TTypography, TypographySpecs>> | "default";
 export type ShadowKey = Join<PathsToStringProps<TShadow>>;
 


### PR DESCRIPTION
The transparent color was ignored as it is not part of the palette keys. The transparent option is a special case that should always be available. This change adds a special "safeColors" array, that is both used to whitelist such values as well as create the type of PaletteKey so they are always in sync