### PR TITLE
[feature] Add base labels to the primitive components

### DIFF
--- a/example/arrow-icon.tsx
+++ b/example/arrow-icon.tsx
@@ -1,14 +1,9 @@
+import { FC } from "react";
 import { IconProps } from "e-prim";
 import { BaseIcon } from "e-prim";
-import { FC } from "react";
 
-export const ArrowIcon: FC<IconProps> = (props) => (
+export const ArrowIcon: FC<IconProps> = props => (
   <BaseIcon {...props}>
-    <path
-      d="M4 12H20M20 12L12 4M20 12L12 20"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
+    <path d="M4 12H20M20 12L12 4M20 12L12 20" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
   </BaseIcon>
 );

--- a/example/button.tsx
+++ b/example/button.tsx
@@ -1,0 +1,8 @@
+import { forwardRef } from "react";
+import { Box, BoxProps } from "e-prim";
+
+type ButtonProps = BoxProps<"button">;
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
+  <Box as="button" ref={ref} {...props} label="button" />
+));

--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable */
 import styled from "@emotion/styled";
 import { Box, Flex, Grid, Typography } from "e-prim";
 import { ArrowIcon } from "../arrow-icon";
+import { Button } from "../button";
 
 const StyledBox = styled(Box)(({ theme: { palette } }) => ({
   color: palette.warning.normal,
@@ -17,6 +19,8 @@ export default function () {
       </Typography>
 
       <ArrowIcon color="success.normal" size={32} />
+
+      <Button>Test Button</Button>
 
       <Box
         onClick={console.log}

--- a/example/theme.ts
+++ b/example/theme.ts
@@ -1,35 +1,33 @@
-const palette = {
-  primary: {
-    normal: "#00659e",
-  },
-  success: {
-    normal: "#20B000",
-  },
-  warning: {
-    normal: "#ffe607",
-    dark: "#cbb700",
-  },
-  neutral: {
-    0: "#ffffff",
-    1: "#f5f5f5",
-    2: "#edecf0",
-    3: "#d8d7df",
-    4: "#898896",
-    5: "#666472",
-    6: "#424149",
-    7: "#27262c",
-    8: "#131316",
-    9: "#050505",
-  },
-};
-
 export const theme = {
   breakpoint: {
     xs: 0,
     md: 500,
   },
   spacing: 4,
-  palette,
+  palette: {
+    primary: {
+      normal: "#00659e",
+    },
+    success: {
+      normal: "#20B000",
+    },
+    warning: {
+      normal: "#ffe607",
+      dark: "#cbb700",
+    },
+    neutral: {
+      0: "#ffffff",
+      1: "#f5f5f5",
+      2: "#edecf0",
+      3: "#d8d7df",
+      4: "#898896",
+      5: "#666472",
+      6: "#424149",
+      7: "#27262c",
+      8: "#131316",
+      9: "#050505",
+    },
+  },
   shadow: {
     xl: "0px 48px 80px -32px rgba(55, 56, 74, 0.12), 0px 64px 132px -20px rgba(55, 56, 74, 0.08)",
   },

--- a/lib/components/box.tsx
+++ b/lib/components/box.tsx
@@ -34,7 +34,7 @@ export const Box: <E extends ElementType = typeof DEFAULT_TAG>(props: BoxProps<E
         ref={ref}
         {...omit(props, ...marginsPropKeys, ...paddingsPropKeys, ...cssPropsKeys)}
         css={(theme: BaseTheme) => ({
-          label,
+          label: label ?? "box",
           ...combineResponsiveValues(
             ...createCssProps(props, theme),
             ...createMargins(props, theme),

--- a/lib/components/flex.tsx
+++ b/lib/components/flex.tsx
@@ -20,6 +20,7 @@ export const Flex: <E extends ElementType = typeof DEFAULT_TAG>(props: FlexProps
   forwardRef(<E extends ElementType = typeof DEFAULT_TAG>(props: FlexProps<E>, ref: Ref<FlexProps<E>["as"]>) => (
     <Box
       ref={ref}
+      label="flex"
       {...omit(props, ...flexPropKeys)}
       css={theme => combineResponsiveValues(...createFlex(props, theme))}
     />

--- a/lib/components/grid.tsx
+++ b/lib/components/grid.tsx
@@ -19,6 +19,7 @@ export const Grid: <E extends ElementType = typeof DEFAULT_TAG>(props: GridProps
     return (
       <Box
         ref={ref}
+        label="grid"
         {...omit(props, ...gridPropKeys)}
         css={theme => combineResponsiveValues(...createGrid(props, theme))}
       />

--- a/lib/components/icon.tsx
+++ b/lib/components/icon.tsx
@@ -33,6 +33,7 @@ export const BaseIcon: FC<BaseIconProps> = ({
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
     color={color}
+    label="icon"
     {...props}
   />
 );

--- a/lib/components/typography.tsx
+++ b/lib/components/typography.tsx
@@ -20,6 +20,7 @@ export const Typography: <E extends ElementType = typeof DEFAULT_TAG>(
     return (
       <Box
         ref={ref}
+        label="typography"
         {...omit(props, ...typographyPropKeys)}
         css={theme => combineResponsiveValues(...createTypography(props, theme))}
       />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5079334/205680118-b00d431d-1a42-4a97-9767-285fadbdd9c8.png)

Adds base labels to the primitives components to make it easier to navigate through the DOM. Those labels are completely overridable from the props passed by the consumer.